### PR TITLE
Added s390x support for multi-arch image building

### DIFF
--- a/.github/workflows/multiarch-build.yaml
+++ b/.github/workflows/multiarch-build.yaml
@@ -61,6 +61,7 @@ jobs:
           buildah manifest create ${{ env.IMAGE_NAME }}
           buildah manifest add ${{ env.IMAGE_NAME }} ${{ env.IMAGE_NAME }}:linux-amd64
           buildah manifest add ${{ env.IMAGE_NAME }} ${{ env.IMAGE_NAME }}:linux-ppc64le
+          buildah manifest add ${{ env.IMAGE_NAME }} ${{ env.IMAGE_NAME }}:linux-s390x
      
      # Authenticate to container image registry to push the image
       - name: Podman Login

--- a/.github/workflows/multiarch-build.yaml
+++ b/.github/workflows/multiarch-build.yaml
@@ -43,6 +43,15 @@ jobs:
           arch: ppc64le
           containerfiles: |
             ./Dockerfile
+            
+      - name: Build image linux/s390x
+        uses: redhat-actions/buildah-build@v2
+        with:
+          image: ${{ env.IMAGE_NAME }}
+          tags: linux-s390x
+          arch: s390x
+          containerfiles: |
+            ./Dockerfile
                
       - name: Check images created
         run: buildah images | grep '${{ env.IMAGE_NAME }}'


### PR DESCRIPTION
Added a few lines in the `multiarch-build.yaml` file so that the image can be built on IBM Z.

Signed-off-by: Lawrence Luo <lluo@redhat.com>